### PR TITLE
Clean up VSCode settings formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,4 +11,3 @@
         ".specify/scripts/powershell/": true
     }
 }
-


### PR DESCRIPTION
Fixes #1

Remove trailing newline from .vscode/settings.json to maintain consistent file formatting.

## Changes
- Removed trailing newline from .vscode/settings.json