### PR TITLE
Enforce Issue-First gates (Refs #17)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+# Summary
+
+Provide a concise summary of the change.
+
+## Issue link (required)
+
+Closes #<issue-number>
+
+> Replace <issue-number> with the GitHub issue this PR resolves. This is required to auto-close the issue on merge.
+
+## Checklist
+
+- [ ] Branch is named `^[0-9]+-[a-z0-9-]+$` (starts with the issue number)
+- [ ] All commits reference the issue (e.g., `Refs #N`), and PR includes `Closes #N`
+- [ ] Tests added and passing (unit/integration as applicable)
+- [ ] Documentation updated (README/quickstart/specs)
+- [ ] Lint/format hooks pass
+- [ ] No secrets added; pre-commit `detect-secrets` passes
+
+## Details
+
+- Motivation and context
+- Key changes and rationale
+- Risks and mitigations

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,3 +87,18 @@ repos:
           - --exclude-files
           - '(\\.venv/|^secrets/|^\.git/)'
         exclude: '(^\.git/|^\.specify/)'
+
+  # Local hooks: enforce Issue-First policy gates
+  - repo: local
+    hooks:
+      - id: enforce-branch-name
+        name: "Enforce branch naming: ^[0-9]+-[a-z0-9-]+$"
+        entry: python3 scripts/git/branch_name_check.py
+        language: system
+        stages: [commit]
+        pass_filenames: false
+      - id: enforce-commit-msg-has-issue
+        name: "Enforce commit message contains issue reference (#N)"
+        entry: python3 scripts/git/commit_msg_check.py
+        language: system
+        stages: [commit-msg]

--- a/scripts/git/branch_name_check.py
+++ b/scripts/git/branch_name_check.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+import re
+import subprocess
+import sys
+
+
+def current_branch() -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
+            stderr=subprocess.DEVNULL,
+        )
+        return out.decode().strip()
+    except subprocess.CalledProcessError:
+        return "HEAD"  # detached
+
+
+def main() -> int:
+    branch = current_branch()
+    # Allow detached HEAD and depend on other hooks to guard merges
+    if branch in ("HEAD", ""):  # pragma: no cover - rare locally
+        return 0
+
+    # main is already protected by no-commit-to-branch
+    if branch == "main":
+        return 0
+
+    pattern = re.compile(r"^[0-9]+-[a-z0-9-]+$")
+    if pattern.fullmatch(branch):
+        return 0
+
+    print(
+        f"Branch '{branch}' does not match required pattern '^[0-9]+-[a-z0-9-]+$'\n"
+        "Create a branch named with the GitHub issue number, e.g.:\n"
+        "  123-fix-login-timeout\n",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/git/commit_msg_check.py
+++ b/scripts/git/commit_msg_check.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import re
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("commit_msg_check: missing commit message file path", file=sys.stderr)
+        return 1
+    msg_path = Path(sys.argv[1])
+    try:
+        text = msg_path.read_text(encoding="utf-8", errors="ignore")
+    except Exception as e:  # pragma: no cover - hook path failure
+        print(f"commit_msg_check: cannot read commit message: {e}", file=sys.stderr)
+        return 1
+
+    first_line = text.splitlines()[0] if text.splitlines() else ""
+
+    # Accept if any of the following holds:
+    # - Subject starts with [N]
+    # - Body or subject contains 'Refs #N' / 'Closes #N' / 'Fixes #N' (case-insensitive)
+    # - Fallback: any '#N' appearance
+    bracket_ok = re.search(r"^\s*\[\d+\]", first_line) is not None
+    verb_ok = re.search(r"(?i)\b(?:refs|closes|fixes)\s+#\d+\b", text) is not None
+    hash_ok = re.search(r"#\d+", text) is not None
+
+    if bracket_ok or verb_ok or hash_ok:
+        return 0
+
+    print(
+        "Commit message must reference an issue number.\n"
+        "Examples:\n"
+        "  [123] Add retry/backoff\n"
+        "  Refactor CSV validation (Refs #123)\n"
+        "  Closes #123: enforce branch naming policy\n",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements enforcement of Issue-First policy.

- commit-msg hook: require an issue reference in commits (e.g., Refs #N / Closes #N)
- branch-name hook: enforce ^[0-9]+-[a-z0-9-]+$ for feature branches
- PR template requiring Closes #N section
- Constitution updated to v2.2.0 with Automation Enforcement

Closes #17