### PR TITLE
Default setup script: secrets on by default; add --no-env; write secrets/.env

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -124,7 +128,7 @@
     {
       "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": [
-        "(\\.venv/|^secrets/|^\\.git/|User-Database\\.csv$)"
+        "(\\\\.venv/|^secrets/|^\\.git/)"
       ]
     }
   ],
@@ -133,16 +137,16 @@
       {
         "type": "Secret Keyword",
         "filename": "scripts/setup_xc_credentials.sh",
-        "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
+        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 28
+        "line_number": 29
       },
       {
         "type": "Secret Keyword",
         "filename": "scripts/setup_xc_credentials.sh",
-        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
+        "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
         "is_verified": false,
-        "line_number": 41
+        "line_number": 48
       }
     ],
     "specs/001-xc-group-sync/spec.md": [
@@ -162,5 +166,5 @@
       }
     ]
   },
-  "generated_at": "2025-11-05T01:02:10Z"
+  "generated_at": "2025-11-05T05:29:06Z"
 }


### PR DESCRIPTION
This PR defaults the setup script to set GitHub repo secrets, adds --no-secrets and --no-env flags, and writes .env to secrets/.env so it stays gitignored.\n\n- Secrets set by default: TENANT_ID, XC_CERT, XC_CERT_KEY, XC_P12, XC_P12_PASSWORD\n- --no-secrets to opt out; --no-env to skip env file\n- Help/usage updated; backward-compatible --set-secrets retained\n\nCloses #23