### PR TITLE
Setup script: no leftover files (atomic writes, cleanup, --tidy-legacy-env) — Closes #33

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,14 +139,14 @@
         "filename": "scripts/setup_xc_credentials.sh",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 29
+        "line_number": 32
       },
       {
         "type": "Secret Keyword",
         "filename": "scripts/setup_xc_credentials.sh",
         "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
         "is_verified": false,
-        "line_number": 48
+        "line_number": 52
       }
     ],
     "specs/001-xc-group-sync/spec.md": [
@@ -166,5 +166,5 @@
       }
     ]
   },
-  "generated_at": "2025-11-05T05:29:06Z"
+  "generated_at": "2025-11-05T17:07:14Z"
 }


### PR DESCRIPTION
Improvements to ensure the setup script leaves no junk files behind:\n- Atomic writes for cert, key, and env using mktemp + install (600) + mv.\n- Trap cleanup to remove temp files on error.\n- umask 077 to enforce restrictive defaults.\n- New flag --tidy-legacy-env to remove an obsolete root .env if it points to secrets/ paths.\n\nOn success, only secrets/cert.pem, secrets/key.pem, and secrets/.env remain. On failure, temp files are removed.\n\nCloses #33