### PR TITLE
chore: pin urllib3<2 to avoid NotOpenSSLWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "python-dotenv>=1.0.1",
   "requests>=2.32.3",
   "tenacity>=9.0.0",
+  "urllib3<2,>=1.26.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Pin urllib3 to v1.x to avoid NotOpenSSLWarning by keeping urllib3<2 until runtime OpenSSL (or CI images) are upgraded.

This change pins `urllib3<2` in `pyproject.toml`.

Testing notes:
- Run `pip install -e .` in the project venv and run tests.
- Consider whether CI images need updating instead of pinning in the long term.
