### PR TITLE
chore: migrate pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       - id: no-commit-to-branch
         args: ["--branch", "main"]
         # Run only at actual commit time so global/all-files scans (CI) don't invoke it
-        stages: [commit]
+        stages: [pre-commit]
 
   - repo: https://github.com/jackdewinter/pymarkdown
     rev: 0b4ac197f67f6ed75e27a10fad70ddc8014cb2e2  # frozen: v0.9.33  # pragma: allowlist secret


### PR DESCRIPTION
Run pre-commit migrate-config to update deprecated stage names (fixes no-commit-to-branch warning).