### PR TITLE
55: fix pip-audit invocation (-P removal)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -163,7 +163,7 @@ repos:
 
       - id: pip-audit-pyproject
         name: "pip-audit (pyproject, strict, CI-only)"
-        entry: bash -eo pipefail -c 'python -m pip install -q --upgrade pip pip-audit; python -m pip install -q . || true; python -m pip_audit --strict -P --progress-spinner off'
+        entry: bash -eo pipefail -c 'python -m pip install -q --upgrade pip pip-audit; python -m pip install -q . || true; python -m pip_audit --strict --progress-spinner off'
         language: system
         pass_filenames: false
         # Run pip-audit against the project when pyproject.toml exists.


### PR DESCRIPTION
Remove unsupported -P flag from pip-audit-pyproject hook. Local validation shows pip-audit fails to audit 'azure-f5xc-diagram-generator' which is not available on PyPI; consider excluding or pinning this dependency.