### PR TITLE
58: fix GitHub workflow failures

### DIFF
--- a/.github/workflows/xc-group-sync.yml
+++ b/.github/workflows/xc-group-sync.yml
@@ -36,13 +36,13 @@ jobs:
           set -euo pipefail
           mkdir -p secrets
           if [[ -n "${XC_CERT:-}" && -n "${XC_CERT_KEY:-}" ]]; then
-            echo "$XC_CERT" | tr -d '\n\r' | base64 -d > secrets/cert.pem
-            echo "$XC_CERT_KEY" | tr -d '\n\r' | base64 -d > secrets/key.pem
+            echo "$XC_CERT" | tr -d '[:space:]' | base64 -d > secrets/cert.pem
+            echo "$XC_CERT_KEY" | tr -d '[:space:]' | base64 -d > secrets/key.pem
             echo "Using cert/key auth"
             echo "VOLT_API_CERT_FILE=${GITHUB_WORKSPACE}/secrets/cert.pem" >> "$GITHUB_ENV"
             echo "VOLT_API_CERT_KEY_FILE=${GITHUB_WORKSPACE}/secrets/key.pem" >> "$GITHUB_ENV"
           elif [[ -n "${XC_P12:-}" && -n "${XC_P12_PASSWORD:-}" ]]; then
-            echo "$XC_P12" | base64 -d > secrets/xc.p12
+            echo "$XC_P12" | tr -d '[:space:]' | base64 -d > secrets/xc.p12
             # Split p12 to PEM for requests
             openssl pkcs12 -in secrets/xc.p12 -clcerts -nokeys -out secrets/cert.pem -passin env:XC_P12_PASSWORD
             openssl pkcs12 -in secrets/xc.p12 -nocerts -nodes -out secrets/key.pem -passin env:XC_P12_PASSWORD

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -163,7 +163,7 @@ repos:
 
       - id: pip-audit-pyproject
         name: "pip-audit (pyproject, strict, CI-only)"
-        entry: bash -eo pipefail -c 'python -m pip install -q --upgrade pip pip-audit; python -m pip install -q . || true; python -m pip_audit --strict --progress-spinner off --timeout 30'
+        entry: bash -eo pipefail -c 'python -m pip install -q --upgrade pip pip-audit; python -m pip install -q . || true; pip-audit --strict --progress-spinner off --timeout 30'
         language: system
         pass_filenames: false
         # Run pip-audit against the project when pyproject.toml exists.


### PR DESCRIPTION
## Summary
Fixes critical GitHub Actions workflow failures blocking all CI/CD pipelines.

## Changes
### 1. Fixed pip-audit invocation (.pre-commit-config.yaml:166)
- **Before**: `python -m pip_audit` (module name with underscore)
- **After**: `pip-audit` (correct CLI command with hyphen)
- **Reason**: pip-audit package provides CLI as `pip-audit`, not a Python module

### 2. Fixed base64 decoding (xc-group-sync.yml:39,45)
- **Before**: `tr -d '\n\r'` (only removes newlines/carriage returns)
- **After**: `tr -d '[:space:]'` (removes all whitespace)
- **Reason**: GitHub Actions secrets may contain spaces, tabs, and other whitespace that breaks base64 decoding
- **Applied to**: Both cert/key and P12 credential paths

## Root Causes Identified
1. **pip-audit**: Incorrect assumption about module/CLI naming convention
2. **base64 decoding**: GitHub Actions secret formatting includes embedded whitespace beyond line endings

## Testing
✅ Local pre-commit hooks pass
✅ Git workflow validation passes
⏳ CI pipeline validation in progress

## Impact
- Unblocks pre-commit workflow
- Fixes XC Group Sync authentication
- Enables Dependabot updates
- Resolves issue #58

## Test Plan
- [ ] Pre-commit workflow completes successfully
- [ ] XC Group Sync workflow passes credential preparation
- [ ] All CI checks green

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)