### PR TITLE
58: Fix xc-group-sync CLI command syntax

### DIFF
--- a/.github/workflows/xc-group-sync.yml
+++ b/.github/workflows/xc-group-sync.yml
@@ -68,9 +68,9 @@ jobs:
 
       - name: Dry-run sync
         run: |
-          xc-group-sync --csv ./User-Database.csv --dry-run --log-level info --timeout 30 --max-retries 3
+          xc-group-sync sync --csv ./User-Database.csv --dry-run --log-level info --timeout 30 --max-retries 3
 
       - name: Apply sync
         if: github.event_name == 'workflow_dispatch'
         run: |
-          xc-group-sync --csv ./User-Database.csv --log-level info --timeout 30 --max-retries 3
+          xc-group-sync sync --csv ./User-Database.csv --log-level info --timeout 30 --max-retries 3


### PR DESCRIPTION
## Summary
Fixes the xc-group-sync CLI invocation by adding the missing `sync` subcommand.

## Root Cause
The CLI uses Click command groups with a `sync` subcommand, but the workflow was calling `xc-group-sync --csv ...` instead of `xc-group-sync sync --csv ...`.

## Changes Made
Updated both dry-run and apply sync steps to include the `sync` subcommand:
- Before: `xc-group-sync --csv ./User-Database.csv ...`
- After: `xc-group-sync sync --csv ./User-Database.csv ...`

## Test Plan
- [x] Local pre-commit checks passed
- [ ] Verify XC Group Sync workflow executes successfully
- [ ] Confirm authentication works end-to-end

## Related Issues
Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)