### PR TITLE
58: keep TENANT_ID as secret for customer privacy

### DIFF
--- a/.github/workflows/xc-group-sync.yml
+++ b/.github/workflows/xc-group-sync.yml
@@ -31,7 +31,7 @@ jobs:
           XC_P12_PASSWORD: ${{ secrets.XC_P12_PASSWORD }}
           XC_CERT: ${{ secrets.XC_CERT }}
           XC_CERT_KEY: ${{ secrets.XC_CERT_KEY }}
-          XC_TENANT_ID: ${{ vars.TENANT_ID }}
+          XC_TENANT_ID: ${{ secrets.TENANT_ID }}
         run: |
           set -euo pipefail
           mkdir -p secrets
@@ -61,10 +61,10 @@ jobs:
             exit 1
           fi
           if [[ -z "${XC_TENANT_ID:-}" ]]; then
-            echo "TENANT_ID variable is required" >&2
+            echo "TENANT_ID secret is required" >&2
             exit 1
           fi
-          # Write TENANT_ID to .env (as repository variable, not secret, so no masking)
+          # Write TENANT_ID to .env (will be masked in logs for customer privacy)
           printf "TENANT_ID=%s\n" "$XC_TENANT_ID" > secrets/.env
           echo "DOTENV_PATH=${GITHUB_WORKSPACE}/secrets/.env" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Summary
Reverts TENANT_ID back to being a repository secret instead of a variable, as it contains customer information that should be masked in logs for privacy.

## Key Insight
**The secret masking is actually a FEATURE, not a bug.** GitHub Actions masking TENANT_ID in logs protects customer privacy, which is desirable. The masking only affects log display - the Python code receives and uses the value correctly to construct URLs.

## Changes
- **Workflow**: Use `secrets.TENANT_ID` instead of `vars.TENANT_ID`
- **Setup script**: Use `gh secret set TENANT_ID` instead of `gh variable set`  
- **Comments**: Updated to reflect privacy reasoning

## Why This Works
1. GitHub Actions reads `secrets.TENANT_ID` correctly
2. Writes value to `secrets/.env` file
3. Python CLI reads from `.env` correctly
4. Python constructs URL: `https://{tenant_id}.console.ves.volterra.io`
5. API calls work fine - masking is only in logs
6. Customer information stays private in workflow logs ✅

## Test Plan
- [x] Setup script creates TENANT_ID as secret
- [x] Local CLI testing confirms functionality  
- [ ] Workflow run verifies API connection works
- [ ] TENANT_ID properly masked in logs for privacy

## Related
Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)