### PR TITLE
057-ignore-coverage: ignore coverage data file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ __pycache__/
 
 # Wheel / binary build dirs
 bdist.*
+.coverage


### PR DESCRIPTION
057-ignore-coverage: ignore coverage data file

Add .coverage to .gitignore to avoid committing environment-specific coverage artifacts. This keeps the repository clean; CI should be used as the authoritative source for coverage reports and artifacts.
