### PR TITLE
Add separate --cleanup-groups and --cleanup-users flags

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -155,16 +155,16 @@
         "filename": "specs/001-xc-group-sync/spec.md",
         "hashed_secret": "6d923384426b4cc3f041c010051a2dba3c77d6e3",
         "is_verified": false,
-        "line_number": 445
+        "line_number": 446
       },
       {
         "type": "Secret Keyword",
         "filename": "specs/001-xc-group-sync/spec.md",
         "hashed_secret": "843f5d95bfcb135014a4e5efd968176d16613907",
         "is_verified": false,
-        "line_number": 448
+        "line_number": 449
       }
     ]
   },
-  "generated_at": "2025-11-05T17:07:14Z"
+  "generated_at": "2025-11-11T18:15:09Z"
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This tool:
 - **Reads** user group memberships from CSV exports (e.g., from Active Directory)
 - **Syncs** RBAC groups to F5 Distributed Cloud via API
 - **Validates** all users exist in XC before creating groups
-- **Manages** group lifecycle (create, update, delete with `--cleanup`)
+- **Manages** group and user lifecycle (create, update, delete with `--cleanup-groups` and `--cleanup-users`)
 - **Provides** dry-run mode for safe testing
 - **Integrates** with CI/CD pipelines (GitHub Actions)
 
@@ -135,18 +135,19 @@ xc-group-sync sync --csv ./User-Database.csv --dry-run --log-level info
 # Apply sync (create/update groups)
 xc-group-sync sync --csv ./User-Database.csv --log-level info
 
-# Apply with cleanup (also delete groups not in CSV)
-xc-group-sync sync --csv ./User-Database.csv --cleanup --log-level info
+# Apply with cleanup (also delete groups and users not in CSV)
+xc-group-sync sync --csv ./User-Database.csv --cleanup-groups --cleanup-users --log-level info
 ```
 
-**⚠️ Warning:** `--cleanup` flag will **delete** F5 XC groups that don't exist in your CSV. Use with caution.
+**⚠️ Warning:** `--cleanup-groups` and `--cleanup-users` flags will **delete** F5 XC groups and users that don't exist in your CSV. Use with caution.
 
 ## Command Options
 
 ```text
 --csv <path>          Path to CSV file with user data (required)
 --dry-run             Preview changes without applying (no API calls)
---cleanup             Delete XC groups not present in CSV (opt-in, use carefully)
+--cleanup-groups      Delete XC groups not present in CSV (opt-in, use carefully)
+--cleanup-users       Delete XC users not present in CSV (opt-in, use carefully)
 --log-level <level>   Logging verbosity: debug|info|warn|error (default: info)
 --timeout <seconds>   HTTP request timeout (default: 30)
 --max-retries <n>     Max retries for transient API errors (default: 3)
@@ -179,7 +180,9 @@ xc-group-sync sync --csv ./User-Database.csv --cleanup --log-level info
 - Adds missing members
 - Removes extra members (if they exist in XC)
 
-**Delete** (with `--cleanup`): Groups in XC but not in CSV are deleted
+**Delete** (with `--cleanup-groups`): Groups in XC but not in CSV are deleted
+
+**Delete Users** (with `--cleanup-users`): Users in XC but not in CSV are deleted
 
 ## CI/CD Integration
 
@@ -258,9 +261,9 @@ sync-xc-groups:
 
 1. **Always dry-run first**: Test with `--dry-run` before applying
 2. **Review changes**: Check dry-run output for unexpected modifications
-3. **Start without cleanup**: Omit `--cleanup` until confident
+3. **Start without cleanup**: Omit `--cleanup-groups` and `--cleanup-users` until confident
 4. **Monitor logs**: Use `--log-level debug` for troubleshooting
-5. **Backup groups**: Document current XC group state before bulk changes
+5. **Backup groups and users**: Document current XC state before bulk changes
 
 ### File Permissions
 

--- a/specs/001-xc-group-sync/quickstart.md
+++ b/specs/001-xc-group-sync/quickstart.md
@@ -53,7 +53,8 @@ Required repo secrets:
 
 ```text
 --dry-run          Log actions without calling the API
---cleanup          Delete XC groups missing from CSV (opt-in)
+--cleanup-groups   Delete XC groups missing from CSV (opt-in)
+--cleanup-users    Delete XC users missing from CSV (opt-in)
 --log-level        debug|info|warn|error (default: info)
 --timeout          HTTP timeout in seconds (default: 30)
 --max-retries      Max retries for transient API errors (default: 3)

--- a/specs/001-xc-group-sync/spec.md
+++ b/specs/001-xc-group-sync/spec.md
@@ -129,14 +129,15 @@ As an operator, I can run a setup script that discovers my F5 XC API certificate
 - **FR-006a**: The tool MUST be idempotent: a second run with unchanged CSV MUST produce zero changes (created=0, updated=0).
 - **FR-007**: The tool MUST support a dry-run mode (`--dry-run` flag) that logs intended actions without performing create/update/delete operations.
 - **FR-008**: The tool MUST produce a summary report including counts of: groups created, groups updated, groups deleted, groups skipped (no change), errors.
-- **FR-009**: When cleanup mode is enabled (`--cleanup` flag), the tool MUST identify groups present in XC but absent from CSV and delete them via `DELETE /api/web/custom/namespaces/system/user_groups/{name}`.
+- **FR-009**: When group cleanup mode is enabled (`--cleanup-groups` flag), the tool MUST identify groups present in XC but absent from CSV and delete them via `DELETE /api/web/custom/namespaces/system/user_groups/{name}`.
+- **FR-009a**: When user cleanup mode is enabled (`--cleanup-users` flag), the tool MUST identify users present in XC but absent from CSV and delete them via the F5 XC API. This flag is independent of `--cleanup-groups` and must be explicitly enabled.
 - **FR-010**: The tool MUST pre-validate that all unique user emails from the CSV exist in F5 XC via `GET /api/web/custom/namespaces/system/user_roles` before performing group operations. The CSV is the authoritative source of truth.
 - **FR-010a**: If users exist in F5 XC but are not present in the CSV, the tool MUST remove them from all XC user groups during sync operations (treating CSV as complete user roster).
 - **FR-011**: The tool MUST implement retry with exponential backoff for transient API failures (5xx errors, rate limit 429) with configurable max retries (default: 3).
 - **FR-012**: The tool MUST log errors with sufficient context (group name, operation, HTTP status, response message) without exposing API tokens in logs.
 - **FR-013**: The tool MUST support configuration via CLI flags for: API base URL, auth token, dry-run, cleanup mode, logging level (debug/info/warn/error), max retries.
 - **FR-014**: The tool MUST use HTTPS/TLS for all API calls (enforce certificate validation) and never print API tokens in logs or stdout.
-- **FR-015**: Destructive operations (deleting groups via `--cleanup`) MUST be disabled by default and require explicit opt-in flag.
+- **FR-015**: Destructive operations (deleting groups via `--cleanup-groups` and users via `--cleanup-users`) MUST be disabled by default and require explicit opt-in flags.
 - **FR-016**: The tool MUST exit with status code 0 if all operations succeed; non-zero (1) if any operation fails or validation errors occur.
 - **FR-017**: The tool MUST operate exclusively in the "system" namespace for all user group operations (hardcoded), as mandated by F5 XC API design. Multi-namespace support is out of scope.
 - **FR-018**: The tool MUST set the `display_name` field for each user group to the extracted CN value (same as `name`), providing consistent human-readable group identifiers.


### PR DESCRIPTION
## Summary
Add explicit --cleanup-groups and --cleanup-users flags for independent cleanup control.

Fixes #82

## Changes
- Add cleanup_orphaned_users() method to UserSyncService
- Rename --cleanup flag to --cleanup-groups for clarity
- Add --cleanup-users flag to sync command  
- Integrate user cleanup into CLI sync workflow
- Update all documentation (specs, README, quickstart)
- Add 4 comprehensive tests for user cleanup functionality

## Key Features
- **Independent flags**: Can be used separately or together
- **Safe defaults**: Both flags disabled by default
- **Dry-run support**: Both cleanup operations respect --dry-run
- **Consistent pattern**: User cleanup follows same pattern as group cleanup

## Usage Examples
```bash
# Clean up only orphaned groups
xc-group-sync sync --csv ./data.csv --cleanup-groups

# Clean up only orphaned users
xc-group-sync sync --csv ./data.csv --cleanup-users

# Clean up both
xc-group-sync sync --csv ./data.csv --cleanup-groups --cleanup-users

# Safe preview
xc-group-sync sync --csv ./data.csv --cleanup-groups --cleanup-users --dry-run
```

## Testing
All 4 new tests pass successfully.