### PR TITLE
Rename repository from f5-xc-rbac to f5-xc-user-group-sync

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# EditorConfig for f5-xc-rbac
+# EditorConfig for f5-xc-user-group-sync
 # https://editorconfig.org
 
 root = true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-# f5-xc-rbac Development Guidelines
+# f5-xc-user-group-sync Development Guidelines
 
 Auto-generated from all feature plans. Last updated: 2025-11-04
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Pre-commit hooks for f5-xc-rbac repository
+# Pre-commit hooks for f5-xc-user-group-sync repository
 # See https://pre-commit.com for more information
 
 repos:

--- a/.serena/memories/codebase_structure.md
+++ b/.serena/memories/codebase_structure.md
@@ -3,7 +3,7 @@
 ## Directory Layout
 
 ```text
-f5-xc-rbac/
+f5-xc-user-group-sync/
 ├── src/xc_rbac_sync/       # Main package
 │   ├── __init__.py         # Package initialization
 │   ├── cli.py              # CLI entry point (Click commands)

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -76,7 +76,7 @@ initial_prompt: ""
 languages:
 - python
 
-project_name: "f5-xc-rbac"
+project_name: "f5-xc-user-group-sync"
 included_optional_tools: []
 
 # whether the project is in read-only mode

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# f5-xc-rbac Development Guidelines
+# f5-xc-user-group-sync Development Guidelines
 
 ## Active Technologies
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Before you start, you need:
 
 ```bash
 # Clone the repository
-git clone https://github.com/robinmordasiewicz/f5-xc-rbac.git
-cd f5-xc-rbac
+git clone https://github.com/robinmordasiewicz/f5-xc-user-group-sync.git
+cd f5-xc-user-group-sync
 
 # Create and activate virtual environment
 python3 -m venv .venv
@@ -426,7 +426,7 @@ Includes:
 
 ## Support
 
-- **GitHub Issues**: https://github.com/robinmordasiewicz/f5-xc-rbac/issues
+- **GitHub Issues**: https://github.com/robinmordasiewicz/f5-xc-user-group-sync/issues
 - **F5 XC Documentation**: https://docs.cloud.f5.com/docs/api
 - **F5 Support**: Contact F5 support for platform-specific issues
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "f5-xc-rbac"
+name = "f5-xc-user-group-sync"
 version = "0.1.0"
-description = "XC RBAC group sync tool"
+description = "F5 XC User and Group Synchronization Tool"
 readme = "README.md"
 requires-python = ">=3.9"
 authors = [{ name = "Robin Mordasiewicz" }]

--- a/specs/001-xc-group-sync/plan.md
+++ b/specs/001-xc-group-sync/plan.md
@@ -31,7 +31,7 @@ Automate synchronization of Active Directory groups to F5 Distributed Cloud (XC)
 
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
-- Issue-First: PASS → https://github.com/robinmordasiewicz/f5-xc-rbac/issues/12
+- Issue-First: PASS → https://github.com/robinmordasiewicz/f5-xc-user-group-sync/issues/12
 - Quality Gates: PRE-COMMIT in place (Markdown, Shell, EditorConfig). Python linters (ruff/black) NOT configured → NEEDS FOLLOW-UP (proposal in next steps).
 - Review Required: Will open PR from feature branch.
 - Clean History: Will squash-and-merge, delete branch.

--- a/specs/041-precommit-requirements/plan.md
+++ b/specs/041-precommit-requirements/plan.md
@@ -3,7 +3,7 @@
 **Branch**: `41-precommit-requirements` | **Date**: 2025-11-05 | **Spec**: specs/041-precommit-requirements/spec.md
 **Input**: Feature specification from `/specs/041-precommit-requirements/spec.md`
 
-Note: Driving Issue: https://github.com/robinmordasiewicz/f5-xc-rbac/issues/41
+Note: Driving Issue: https://github.com/robinmordasiewicz/f5-xc-user-group-sync/issues/41
 
 ## Summary
 

--- a/specs/059-user-lifecycle/quickstart.md
+++ b/specs/059-user-lifecycle/quickstart.md
@@ -18,7 +18,7 @@
 
 ```bash
 # 1. Activate project with Serena (if using Serena MCP)
-# Already done: f5-xc-rbac project activated
+# Already done: f5-xc-user-group-sync project activated
 
 # 2. Checkout feature branch
 git checkout 059-user-lifecycle

--- a/specs/060-repository-automation/spec.md
+++ b/specs/060-repository-automation/spec.md
@@ -143,8 +143,8 @@ As a repository administrator, I can configure security features (vulnerability 
     "required_conversation_resolution": true
   },
   "repository": {
-    "description": "F5 XC RBAC synchronization tool",
-    "homepage": "https://github.com/robinmordasiewicz/f5-xc-rbac",
+    "description": "F5 XC User and Group Synchronization Tool",
+    "homepage": "https://github.com/robinmordasiewicz/f5-xc-user-group-sync",
     "topics": ["f5", "xc", "rbac", "python", "automation"],
     "vulnerability_alerts": true,
     "automated_security_fixes": true,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-"""Test suite for f5-xc-rbac."""
+"""Test suite for f5-xc-user-group-sync."""


### PR DESCRIPTION
## Summary

Renames the repository from `f5-xc-rbac` to `f5-xc-user-group-sync` to better represent the tool's functionality of synchronizing both users and groups.

## Changes

- ✅ Renamed GitHub repository via gh CLI
- ✅ Updated package name in pyproject.toml
- ✅ Updated all GitHub URLs (13 files)
- ✅ Updated project name in documentation and configs
- ✅ Updated git remote URL

## Why This Change?

The new name `f5-xc-user-group-sync` accurately describes what the tool does - it synchronizes both **users** AND **groups** from CSV to F5 XC, not just RBAC groups.

## Files Modified

- README.md - Clone instructions and support URLs
- pyproject.toml - Package name and description
- CLAUDE.md - Project title
- .github/copilot-instructions.md - Project name
- .editorconfig - Header comment
- .pre-commit-config.yaml - Header comment
- .serena/project.yml - Project name
- .serena/memories/codebase_structure.md - Directory paths
- specs/060-repository-automation/spec.md - Homepage URL
- specs/041-precommit-requirements/plan.md - Issue URL
- specs/001-xc-group-sync/plan.md - Issue URL
- specs/059-user-lifecycle/quickstart.md - Project name
- tests/__init__.py - Docstring

## Testing

- ✅ All pre-commit hooks pass
- ✅ No remaining references to old name
- ✅ Git remote URL working
- ✅ GitHub repository successfully renamed

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)