### PR TITLE
Security: Upgrade urllib3 to 2.5.0 (CVE-2025-50181)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "python-dotenv>=1.0.1",
   "requests>=2.32.3",
   "tenacity>=9.0.0",
-  "urllib3<2,>=1.26.0",
+  "urllib3>=2.5.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
Fixes Dependabot alert #1

Upgrades urllib3 from <2 to >=2.5.0 to address security vulnerability CVE-2025-50181.

## Security Issue
**CVE-2025-50181** - urllib3 redirects are not disabled when retries are disabled on PoolManager instantiation

- **GHSA ID:** GHSA-pq67-6m6q-mj2v
- **Severity:** Medium (CVSS 5.3)
- **CWE:** CWE-601 (URL Redirection to Untrusted Site)

## Problem
The vulnerability allows redirects to proceed even when they should be disabled at the PoolManager level, potentially enabling SSRF and open redirect attacks.

## Solution
✅ Upgraded urllib3 to version 2.5.0 which includes the security patch

## Changes
- **pyproject.toml**: Updated urllib3 constraint
  - Before: `urllib3<2,>=1.26.0`
  - After: `urllib3>=2.5.0`

## Testing
✅ Tool functionality verified with urllib3 2.5.0
✅ Dry-run operations work correctly
✅ Live sync operations work correctly  
✅ No breaking changes detected

```bash
# Verification
python3 -c "import urllib3; print(f'urllib3 {urllib3.__version__}')"
# urllib3 2.5.0

xc_user_group_sync --csv User-Database.csv --dry-run
# ✅ SYNCHRONIZATION COMPLETE
```

## References
- [GitHub Security Advisory](https://github.com/urllib3/urllib3/security/advisories/GHSA-pq67-6m6q-mj2v)
- [NVD CVE Entry](https://nvd.nist.gov/vuln/detail/CVE-2025-50181)
- [urllib3 Patch Commit](https://github.com/urllib3/urllib3/commit/f05b1329126d5be6de501f9d1e3e36738bc08857)