### PR TITLE
Add specifications content to documentation navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,21 @@ nav:
   - Configuration: configuration.md
   - CLI Reference: cli-reference.md
   - Development: development.md
+  - Specifications:
+    - Overview: specifications/README.md
+    - User Group Sync SRS: specifications/user-group-sync-srs.md
+    - User Lifecycle Management SRS: specifications/user-lifecycle-management-srs.md
+    - Development:
+      - Quality Standards: specifications/development/quality-standards.md
+    - Implementation:
+      - Workflows: specifications/implementation/workflows.md
+      - Testing Strategy: specifications/implementation/testing-strategy.md
+      - Roadmap: specifications/implementation/roadmap.md
+    - Guides:
+      - Deployment Guide: specifications/guides/deployment-guide.md
+      - GitHub Actions Guide: specifications/guides/github-actions-guide.md
+      - Jenkins Guide: specifications/guides/jenkins-guide.md
+      - Troubleshooting Guide: specifications/guides/troubleshooting-guide.md
 
 repo_name: robinmordasiewicz/f5-xc-user-group-sync
 repo_url: https://github.com/robinmordasiewicz/f5-xc-user-group-sync


### PR DESCRIPTION
## Summary

Add all existing specification documents to the mkdocs.yml navigation so they appear in the GitHub Pages documentation site.

## Changes

Updated  navigation to include:

### Specifications Section
- **Overview**: specifications/README.md
- **SRS Documents**:
  - User Group Sync SRS
  - User Lifecycle Management SRS
- **Development**:
  - Quality Standards
- **Implementation**:
  - Workflows
  - Testing Strategy
  - Roadmap
- **Guides**:
  - Deployment Guide
  - GitHub Actions Guide
  - Jenkins Guide
  - Troubleshooting Guide

## Impact

All specification content that exists in  will now be:
- Visible in the documentation site navigation
- Searchable through the site search
- Accessible to users at https://robinmordasiewicz.github.io/f5-xc-user-group-sync/

## Testing

- [x] Pre-commit hooks pass
- [x] mkdocs.yml syntax valid
- [ ] Documentation site build (will verify after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>