### PR TITLE
Create ultra-minimal README with documentation link only

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,44 +10,7 @@ Automated synchronization tool for managing F5 Distributed Cloud (XC) users and 
 
 ## 📖 Documentation
 
-**Complete documentation:** https://robinmordasiewicz.github.io/f5-xc-user-group-sync/
-
-## Overview
-
-Reconciles F5 Distributed Cloud users and groups with your authoritative user database (CSV). Enables automated user lifecycle management and group membership synchronization from identity sources like Active Directory or LDAP.
-
-### Key Features
-
-- 🔄 Automated reconciliation between CSV and F5 XC
-- ✅ Pre-validates CSV data before changes
-- 🔒 Safe dry-run mode
-- 🚀 CI/CD ready (GitHub Actions, Jenkins)
-- 🧪 Well-tested: 195 tests, 93% coverage
-
-## Quick Start
-
-```bash
-# Installation
-git clone https://github.com/robinmordasiewicz/f5-xc-user-group-sync.git
-cd f5-xc-user-group-sync
-python3 -m venv .venv && source .venv/bin/activate
-pip install -e .
-
-# Setup credentials
-./scripts/setup_xc_credentials.sh --p12 ~/Downloads/your-tenant.p12
-
-# Run
-source secrets/.env
-xc_user_group_sync --csv ./User-Database.csv --dry-run
-xc_user_group_sync --csv ./User-Database.csv
-```
-
-**See the [documentation](https://robinmordasiewicz.github.io/f5-xc-user-group-sync/) for complete installation, configuration, and usage instructions.**
-
-## Support
-
-- **Documentation**: https://robinmordasiewicz.github.io/f5-xc-user-group-sync/
-- **Issues**: https://github.com/robinmordasiewicz/f5-xc-user-group-sync/issues
+**https://robinmordasiewicz.github.io/f5-xc-user-group-sync/**
 
 ## License
 


### PR DESCRIPTION
## Summary

Create an ultra-minimal README containing only essential elements, eliminating all content duplication with the documentation site.

## Changes

**File Modifications:**
- : 59 → 22 lines (63% reduction)
- **Total from original**: 958 → 22 lines (98% reduction)

**Three-Phase Optimization:**

| Phase | PR | Lines | Reduction |
|-------|-----|-------|-----------|
| Original | - | 958 | - |
| Phase 1 | #129 | 135 | 86% |
| Phase 2 | #131 | 59 | 94% |
| **Phase 3** | **#132** | **22** | **98%** |

**Removed Sections:**
- ❌ Overview and detailed description
- ❌ Key Features list
- ❌ Quick Start installation guide
- ❌ Support links section

**Retained Essentials:**
- ✅ Project title + one-line description
- ✅ Complete badge set (Python, License, Quality, Coverage, Docs)
- ✅ Prominent documentation link
- ✅ License reference
- ✅ Maintainer information

## Benefits

- **Absolute minimum**: Only essential landing page elements
- **Zero duplication**: All content exclusively in documentation site
- **Single purpose**: Direct users to comprehensive docs
- **Industry standard**: Follows best practices for externally documented projects
- **Minimal maintenance**: No synchronization needed

## Documentation Coverage

All removed content comprehensively available at:
https://robinmordasiewicz.github.io/f5-xc-user-group-sync/

- Installation guide
- Configuration reference
- CLI usage examples
- Development guidelines
- Architecture specifications
- Troubleshooting guide
- CI/CD integration samples

## Pre-commit Verification

All 24 pre-commit hooks passed:
- ✅ PyMarkdown
- ✅ EditorConfig
- ✅ All security and quality checks

Closes #132