### PR TITLE
fix: add missing email-validator dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ license = { text = "MIT" }
 dependencies = [
   "click>=8.3.0",
   "cryptography>=42.0.0",
+  "email-validator>=2.0.0",
   "ldap3>=2.9.1",
   "pydantic>=2.12.4",
   "python-dotenv>=1.2.1",


### PR DESCRIPTION
## Summary

Fixes #140 - Adds missing `email-validator` dependency that was causing ImportError for users after fresh installation.

## Problem

Users installing the package encountered this error when running the CLI:

```
ImportError: email-validator is not installed, run `pip install 'pydantic[email]'`
```

## Root Cause

The `User` model in `src/xc_user_group_sync/models.py` uses pydantic's `EmailStr` type (line 33), which requires the `email-validator` package. This dependency was not listed in `pyproject.toml`.

## Changes

- Added `email-validator>=2.0.0` to the dependencies list in `pyproject.toml`

## Testing

Verified fix by:
1. Creating fresh virtual environment
2. Installing package: `pip install .`
3. Confirming `email-validator 2.3.0` installs automatically
4. Successfully running `xc_user_group_sync --help`

## Impact

- **Severity**: High - This bug blocked all users from using the CLI after fresh installation
- **Type**: Bug fix
- **Files Modified**: `pyproject.toml` (1 line added)
- **Breaking Changes**: None

## Pre-commit Status

All hooks passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)