### PR TITLE
docs: standardize authentication to P12 certificate with passphrase

### DIFF
--- a/src/xc_user_group_sync/cli.py
+++ b/src/xc_user_group_sync/cli.py
@@ -227,8 +227,8 @@ def cli(
 
     Authentication via environment variables:
     - TENANT_ID (required): Your XC tenant ID
-    - XC_API_TOKEN: API token for authentication
-    - VOLT_API_CERT_FILE + VOLT_API_CERT_KEY_FILE: Certificate-based auth
+    - VOLT_API_P12_FILE + VES_P12_PASSWORD: P12 certificate with passphrase
+    - XC_API_URL (optional): Custom API endpoint (e.g., staging environment)
 
     Examples:
         # Reconcile users and groups (create/update only)


### PR DESCRIPTION
## Summary

Fixes #144 - Standardizes all authentication documentation to use P12 certificate with passphrase as the only method, removing legacy cert/key and API token references.

## Problem

Documentation contained references to multiple authentication methods (P12, cert/key pairs, API tokens) which creates confusion for alpha code that should have a single standard approach.

## Changes

### docs/troubleshooting.md

**Issue 1: Authentication Failures**
- ✅ Simplified to P12-only authentication
- ❌ Removed API token references
- ❌ Removed cert/key pair references  
- ✅ Clearer troubleshooting steps for P12

**Test API Connectivity**
- ✅ Updated curl examples to extract cert/key from P12
- ✅ Added staging environment testing with `XC_API_URL`
- ✅ Added recommendation to use Python interactive debugging
- ❌ Removed `VOLT_API_CERT_FILE` and `VOLT_API_CERT_KEY_FILE` examples

### src/xc_user_group_sync/cli.py

**CLI Help Text Updates**
- ✅ Documented `VOLT_API_P12_FILE` + `VES_P12_PASSWORD` as standard
- ✅ Added `XC_API_URL` as optional parameter for staging
- ❌ Removed `XC_API_TOKEN` references
- ❌ Removed `VOLT_API_CERT_FILE/KEY_FILE` references

## Authentication Standard

**Standard Method** (only documented method):
```bash
# Required environment variables
TENANT_ID=your-tenant
VOLT_API_P12_FILE=/path/to/cert.p12
VES_P12_PASSWORD=your-password

# Optional
XC_API_URL=https://tenant.staging.volterra.us  # For staging
```

## Benefits

✅ **Single authentication method** - No confusion about which method to use  
✅ **Simplified troubleshooting** - Clear, focused resolution steps  
✅ **Alpha code clarity** - Documentation reflects implementation reality  
✅ **Better user experience** - Clear path forward without legacy options

## Testing

- All pre-commit hooks passed ✅
- PyMarkdown validation passed ✅
- Ruff and Black formatting passed ✅
- No security issues detected ✅

## Documentation Quality

curl examples now properly show:
1. Extract cert/key from P12 file
2. Use extracted credentials with curl
3. Cleanup temporary files
4. Recommend Python interactive debugging as preferred method

🤖 Generated with [Claude Code](https://claude.com/claude-code)