### PR TITLE
docs: remove NO_PROXY references - not applicable for this tool

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,6 @@ The tool uses these environment variables for authentication and configuration:
 | `XC_API_URL` | No | F5 XC API endpoint URL (for staging) | `https://{TENANT_ID}.console.ves.volterra.io` |
 | `HTTP_PROXY` | No | HTTP proxy URL | None |
 | `HTTPS_PROXY` | No | HTTPS proxy URL | None |
-| `NO_PROXY` | No | Comma-separated bypass list | None |
 | `REQUESTS_CA_BUNDLE` | No | Path to CA certificate bundle | System CA bundle |
 | `CURL_CA_BUNDLE` | No | Alternative CA bundle path | System CA bundle |
 
@@ -51,7 +50,6 @@ If your organization uses an outbound proxy (especially with MITM SSL inspection
 # Add to secrets/.env
 HTTP_PROXY=http://proxy.example.com:8080
 HTTPS_PROXY=http://proxy.example.com:8080
-NO_PROXY=localhost,127.0.0.1,.local
 
 # For proxies with authentication
 HTTPS_PROXY=http://username:password@proxy.example.com:8080  # pragma: allowlist secret

--- a/docs/specifications/user-lifecycle-management-srs.md
+++ b/docs/specifications/user-lifecycle-management-srs.md
@@ -2185,7 +2185,7 @@ The system supports execution through corporate network proxies with MITM (Man-I
 
 ### 3.7.2 Functional Requirements
 
-**FR-020**: System SHALL support HTTP/HTTPS proxy configuration via environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`)
+**FR-020**: System SHALL support HTTP/HTTPS proxy configuration via environment variables (`HTTP_PROXY`, `HTTPS_PROXY`)
 
 **FR-021**: System SHALL support custom CA certificate bundles for SSL verification to accommodate corporate MITM proxies
 
@@ -2204,7 +2204,6 @@ The system supports execution through corporate network proxies with MITM (Man-I
 
 2. **Environment Variables**: Standard proxy environment variables
    - `HTTP_PROXY` / `HTTPS_PROXY`: Proxy URLs for HTTP/HTTPS traffic
-   - `NO_PROXY`: Comma-separated bypass list
    - `REQUESTS_CA_BUNDLE` / `CURL_CA_BUNDLE`: CA certificate bundle path
 
 3. **System Defaults**: System CA certificate store (when no custom configuration provided)
@@ -2214,8 +2213,6 @@ The system supports execution through corporate network proxies with MITM (Man-I
 **AC-020.1**: Tool successfully connects through HTTP proxy when `HTTP_PROXY` environment variable is set
 
 **AC-020.2**: Tool successfully connects through HTTPS proxy when `HTTPS_PROXY` environment variable is set
-
-**AC-020.3**: Tool bypasses proxy for domains listed in `NO_PROXY` environment variable
 
 **AC-021.1**: Tool accepts custom CA certificate bundle via `REQUESTS_CA_BUNDLE` environment variable
 
@@ -2387,7 +2384,6 @@ xc_user_group_sync --csv /path/to/users.csv --prune --dry-run
 | `DOTENV_PATH` | No | Custom path to .env file (overrides default) | `/custom/path/.env` |
 | `HTTP_PROXY` | No | HTTP proxy URL for outbound requests | `http://proxy.example.com:8080` |
 | `HTTPS_PROXY` | No | HTTPS proxy URL for outbound requests | `https://proxy.example.com:8443` |
-| `NO_PROXY` | No | Comma-separated list of hosts to bypass proxy | `localhost,127.0.0.1,.local` |
 | `REQUESTS_CA_BUNDLE` | No | Path to CA certificate bundle for SSL verification | `/etc/ssl/certs/ca-bundle.crt` |
 | `CURL_CA_BUNDLE` | No | Alternative CA bundle path (fallback to REQUESTS_CA_BUNDLE) | `/etc/ssl/certs/ca-certificates.crt` |
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -209,7 +209,6 @@ curl -v --max-time 10 \
 # Option 1: Configure proxy via environment variables (recommended)
 export HTTP_PROXY="http://proxy.example.com:8080"
 export HTTPS_PROXY="http://proxy.example.com:8080"
-export NO_PROXY="localhost,127.0.0.1"
 
 # If proxy requires authentication
 export HTTP_PROXY="http://username:password@proxy.example.com:8080"  # pragma: allowlist secret

--- a/src/xc_user_group_sync/client.py
+++ b/src/xc_user_group_sync/client.py
@@ -97,7 +97,7 @@ class XCClient:
             self.session.proxies = {"http": proxy, "https": proxy}
             logger.debug(f"Using explicit proxy: {proxy}")
         elif os.getenv("HTTP_PROXY") or os.getenv("HTTPS_PROXY"):
-            # requests.Session automatically uses HTTP_PROXY/HTTPS_PROXY/NO_PROXY
+            # requests.Session automatically uses HTTP_PROXY/HTTPS_PROXY env vars
             # Just log for visibility
             http_proxy = os.getenv("HTTP_PROXY") or os.getenv("http_proxy")
             https_proxy = os.getenv("HTTPS_PROXY") or os.getenv("https_proxy")


### PR DESCRIPTION
## Problem

NO_PROXY environment variable is documented throughout codebase but provides no value for this specific tool, adding unnecessary complexity.

## Analysis

This tool **only** communicates with F5 XC API endpoints:
- `login.ves.volterra.io`
- `{tenant}.console.ves.volterra.io`

NO_PROXY is designed to bypass proxy for specific destinations (e.g., localhost, internal domains). Since this tool has no use case for bypassing proxy for any destination, the configuration option adds confusion without benefit.

## Changes

**Documentation**:
- `docs/configuration.md`: Removed NO_PROXY from environment variable table and examples
- `docs/troubleshooting.md`: Removed NO_PROXY from proxy configuration example

**Code**:
- `src/xc_user_group_sync/client.py`: Updated comment to remove NO_PROXY reference (shortened for ruff compliance)

**Specifications**:
- `docs/specifications/user-lifecycle-management-srs.md`: Removed NO_PROXY from:
  - FR-020 functional requirement
  - Proxy configuration methods section
  - AC-020.3 acceptance criteria
  - Environment variables table

## Impact

- ✅ Simpler proxy configuration for users
- ✅ Removes confusing documentation that suggested unnecessary configuration
- ✅ No functional change (NO_PROXY was never needed for this use case)
- ✅ Cleaner proxy examples focusing on what users actually need

## Testing

- ✅ All 24 pre-commit hooks passed
- ✅ Ruff compliance verified
- ✅ No functional code changes

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)