### PR TITLE
Simplify landing page and update documentation navigation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,130 +1,57 @@
 # F5 Distributed Cloud User and Group Sync
 
-Automated synchronization tool for managing F5 XC users and groups from CSV user databases.
+Synchronizes users and groups from CSV to F5 Distributed Cloud.
 
-Synchronizes users and groups between your CSV database and F5 Distributed Cloud:
+## Getting Started
 
-- Creates users/groups that exist in CSV but not in F5 XC
-- Updates user attributes and group memberships to match CSV
-- Optionally prunes users/groups not in CSV (with `--prune` flag)
-
-## Prerequisites
-
-1. **Python 3.9 or higher** installed
-
-   ```bash
-   python3 --version  # Should show 3.9 or higher
-   ```
-
-2. **F5 XC API credentials** (P12 certificate with password)
-   - Download from: F5 XC Console → Administration → Credentials → API Credentials
-   - Save the `.p12` file securely (e.g., `~/Downloads/your-tenant.p12`)
-
-3. **CSV export** from your user database
-   - Must include user emails and group memberships in LDAP DN format
-
-## Installation
-
-### Option 1: Local Development Installation
+### 1. Create Virtual Environment
 
 ```bash
-# Clone the repository
-git clone https://github.com/robinmordasiewicz/f5-xc-user-group-sync.git
-cd f5-xc-user-group-sync
-
-# Create and activate virtual environment
 python3 -m venv .venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-
-# Install in development mode
-pip install -e .
-
-# Verify installation
-xc_user_group_sync --help
 ```
 
-### Option 2: Direct Installation from Git
+### 2. Install
 
 ```bash
-# Install directly from GitHub
 pip install git+https://github.com/robinmordasiewicz/f5-xc-user-group-sync.git
-
-# Verify installation
-xc_user_group_sync --help
 ```
 
-## Quick Start
-
-### 1. Setup Credentials
-
-Use the automated setup script with intelligent proxy detection:
+### 3. Setup Credentials
 
 ```bash
-# Auto-detects .p12 file in ~/Downloads
 ./scripts/setup_xc_credentials.sh
-
-# Or specify P12 file path
-./scripts/setup_xc_credentials.sh --p12 ~/Downloads/your-tenant.p12
-
-# Optionally set GitHub repository secrets for CI/CD
-./scripts/setup_xc_credentials.sh --p12 ~/Downloads/your-tenant.p12 --github-secrets
 ```
 
-The script will:
-- Extract tenant ID from the P12 filename
-- Copy P12 file to `secrets/` directory
-- **Test API connectivity** to detect network requirements
-- **Prompt for proxy configuration** if direct connection fails (interactive mode)
-- Create `secrets/.env` with P12 authentication and optional proxy settings
-- Optionally set GitHub repository secrets (with `--github-secrets` flag)
+The script will auto-detect your P12 certificate and configure the environment.
 
-**Intelligent Proxy Detection**:
-- ✅ **Direct connection works**: No proxy configuration added
-- ⚠️ **Connection fails**: Interactive prompts guide through proxy setup
-  - Asks if you use a corporate proxy
-  - Tests proxy connectivity
-  - Detects MITM SSL inspection needs
-  - Prompts for CA certificate location
-  - Adds proxy settings to `secrets/.env` automatically
-
-**Note**: The tool uses native P12 authentication. Certificate and key are extracted at runtime into temporary files and automatically cleaned up.
-
-### 2. Prepare Your CSV File
-
-See the [CSV Format](configuration.md#csv-format) section for complete specifications.
-
-### 3. Test with Dry-Run
-
-Always test first to preview changes:
+### 4. Load Environment
 
 ```bash
 source secrets/.env
-xc_user_group_sync --csv ./User-Database.csv --dry-run
 ```
 
-### 4. Apply Changes
-
-Once satisfied with dry-run results:
+### 5. Run
 
 ```bash
-xc_user_group_sync --csv ./User-Database.csv
-```
+# Preview changes
+xc_user_group_sync --csv User-Database.csv --dry-run
 
-See [CLI Reference](cli-reference.md) for all available options including `--prune`, `--log-level`, `--timeout`, and more.
+# Apply changes
+xc_user_group_sync --csv User-Database.csv
+
+# Full reconciliation (includes cleanup)
+xc_user_group_sync --csv User-Database.csv --prune
+```
 
 ## Documentation
 
-- **[CLI Reference](cli-reference.md)** - Command options
-- **[Configuration](configuration.md)** - Environment variables and CSV format
-- **[Troubleshooting](troubleshooting.md)** - Common issues
+- [Configuration](configuration.md)
+- [CLI Reference](cli-reference.md)
+- [Troubleshooting](troubleshooting.md)
 
-### CI/CD Examples
+## CI/CD Examples
 
-- **[GitHub Actions](CICD/github-actions.md)** - Automated workflow
-- **[GitLab CI](CICD/gitlab-ci.md)** - Pipeline configuration
-- **[Jenkins](CICD/jenkins.md)** - Jenkinsfile example
-
-## Support
-
-- **Repository**: [github.com/robinmordasiewicz/f5-xc-user-group-sync](https://github.com/robinmordasiewicz/f5-xc-user-group-sync)
-- **Issues**: [GitHub Issues](https://github.com/robinmordasiewicz/f5-xc-user-group-sync/issues)
+- [GitLab CI](CICD/gitlab-ci.md)
+- [GitHub Actions](CICD/github-actions.md)
+- [Jenkins](CICD/jenkins.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,16 +12,13 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - Getting Started: get-started.md
   - Configuration: configuration.md
   - CLI Reference: cli-reference.md
-  - Operations Guide: operations-guide.md
   - Troubleshooting: troubleshooting.md
-  - Development: development.md
   - CI/CD:
-    - Deployment Guide: CICD/deployment-guide.md
-    - GitHub Actions Guide: CICD/github-actions-guide.md
-    - Jenkins Guide: CICD/jenkins-guide.md
+    - GitLab CI: CICD/gitlab-ci.md
+    - GitHub Actions: CICD/github-actions.md
+    - Jenkins: CICD/jenkins.md
   - Specifications:
     - Overview: specifications/README.md
     - User Group Sync SRS: specifications/user-group-sync-srs.md


### PR DESCRIPTION
## Summary

Simplify user-facing documentation to reduce verbosity and improve clarity.

## Changes

### docs/index.md (130 → 58 lines, 55% reduction)
- Complete rewrite to minimal landing page
- Simple 5-step getting started guide (venv → install → setup → load env → run)
- Three example commands (dry-run, apply, prune)
- Links to documentation and CI/CD examples
- Removed verbose prerequisites section
- Removed installation options details
- Removed proxy detection explanation
- Removed CSV format details (linked to configuration.md instead)

### mkdocs.yml Navigation
**Removed references to deleted files:**
- get-started.md
- operations-guide.md
- development.md
- CICD/deployment-guide.md
- CICD/github-actions-guide.md
- CICD/jenkins-guide.md

**Added new CI/CD files:**
- CICD/gitlab-ci.md
- CICD/github-actions.md
- CICD/jenkins.md

## Result

Cleaner, more focused documentation that gets users started faster.

## Pre-commit Compliance

✅ All 24 pre-commit hooks passed successfully:
- PyMarkdown (no MD032 or other formatting issues)
- EditorConfig checks
- detect-secrets
- All other quality checks

## Related

- Closes #158
- Follows PR #155 (initial documentation simplification)
- Follows PR #157 (NO_PROXY removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)