### PR TITLE
Remove security section and fix mkdocs navigation link

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,21 +130,3 @@ CN=EADMIN_STD,OU=Groups,DC=example,DC=com
 "Alice Anderson","CN=USER001,OU=Users,DC=example,DC=com","alice@example.com","memberOf","CN=EADMIN_STD,OU=Groups,DC=example,DC=com"
 "Bob Brown","CN=USER002,OU=Users,DC=example,DC=com","bob@example.com","memberOf","CN=EADMIN_STD,OU=Groups,DC=example,DC=com"
 ```
-
-## Security Best Practices
-
-**✅ DO:**
-
-- Store credentials in `secrets/` directory (gitignored)
-- Use repository secrets for CI/CD
-- Set restrictive permissions: `chmod 600` on P12 files
-- Rotate API credentials regularly
-- Use separate credentials for dev/staging/production
-- Use strong passwords for P12 files
-
-**❌ DON'T:**
-
-- Commit `.p12` or `.env` files to git
-- Share credentials in logs or documentation
-- Use production credentials in development
-- Store P12 passwords in plain text outside of secure storage

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ nav:
   - Configuration: configuration.md
   - CLI Reference: cli-reference.md
   - Troubleshooting: troubleshooting.md
-  - Contributing: CONTRIBUTING.md
+  - Contributing: contributing.md
   - CI/CD:
     - GitLab CI: CICD/gitlab-ci.md
     - GitHub Actions: CICD/github-actions.md


### PR DESCRIPTION
## Summary

Final documentation cleanup: remove unnecessary security section and fix broken navigation link.

## Changes

### 1. Remove Security Best Practices Section (18 lines)

**File**: `docs/configuration.md` (151 → 133 lines, 12% reduction)

**Removed content**:
```markdown
## Security Best Practices

✅ DO:
- Store credentials in secrets/ directory (gitignored)
- Use repository secrets for CI/CD
- Set restrictive permissions: chmod 600 on P12 files
- Rotate API credentials regularly
- Use separate credentials for dev/staging/production
- Use strong passwords for P12 files

❌ DON'T:
- Commit .p12 or .env files to git
- Share credentials in logs or documentation
- Use production credentials in development
- Store P12 passwords in plain text outside of secure storage
```

**Rationale**: Common security knowledge that adds unnecessary verbosity to configuration guide.

### 2. Fix Broken Navigation Link

**File**: `mkdocs.yml`
- **Issue**: Referenced `CONTRIBUTING.md` (uppercase)
- **Actual file**: `contributing.md` (lowercase)
- **Fix**: Changed reference to match actual filename

## Verification

✅ All markdown files verified to exist
✅ All mkdocs.yml navigation links functional
✅ No broken references in documentation

**Documentation files**:
- index.md ✓
- configuration.md ✓
- cli-reference.md ✓
- troubleshooting.md ✓
- contributing.md ✓
- CICD/gitlab-ci.md ✓
- CICD/github-actions.md ✓
- CICD/jenkins.md ✓

## Pre-commit Compliance

✅ All 24 pre-commit hooks passed successfully:
- PyMarkdown (no formatting issues)
- EditorConfig checks
- detect-secrets
- jscpd (DRY duplication scan)
- All other quality checks

## Impact

- Cleaner configuration guide focused on essential setup
- All navigation working correctly
- Continued progress toward minimal, comprehensive documentation

## Related

- Closes #162
- Follows PR #161 (documentation redundancy elimination)
- Follows PR #159 (landing page simplification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)