### PR TITLE
Fix CSV format documentation to match actual implementation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,34 +99,60 @@ For proxy troubleshooting, see [Troubleshooting Guide - Corporate Proxy](trouble
 
 ### Required Columns
 
-Your CSV must include these exact column headers:
+The tool extracts user and group data from CSV exports. Your CSV **must** include these four required columns (other columns are ignored):
 
-- **User Name** (optional): Display name for the user
-- **Login ID** (required): LDAP Distinguished Name in DN format
-- **Email** (required): User's email address matching their F5 XC profile
-- **Entitlement Attribute** (required): Must contain `memberOf`
-- **Entitlement Display Name** (required): Group LDAP DN
+| Column | Required | Description | Example Value |
+|--------|----------|-------------|---------------|
+| **Email** | Yes | User's email address for F5 XC authentication | `alice.anderson@example.com` |
+| **User Display Name** | Yes | Full name of the user | `Alice Anderson` |
+| **Employee Status** | Yes | User account status | `A` (Active) or `I` (Inactive) |
+| **Entitlement Display Name** | Yes | Group membership in LDAP DN format | `CN=EADMIN_STD,OU=Groups,DC=example,DC=com` |
 
-### LDAP DN Format
+**Note**: Your CSV export may contain additional columns (e.g., Login ID, Manager Name, Cost Center) - these are allowed but not used by the synchronization tool.
 
-Both user and group identifiers must be in LDAP Distinguished Name format:
+### Employee Status Values
 
-**User DN Example:**
+The tool recognizes these status values:
 
-```text
-CN=USER001,OU=Users,DC=example,DC=com
-```
+- **Active users**: `A` or `a` (case-insensitive, whitespace trimmed)
+- **Inactive users**: Any other value (e.g., `I`, `T`, `Active`, `Inactive`, `Terminated`)
 
-**Group DN Example:**
+**Important**: Only the single letter `A` marks users as active. Full words like `Active` are treated as inactive.
+
+### Group DN Format
+
+Group identifiers must be in LDAP Distinguished Name format:
+
+**Single Group Example:**
 
 ```text
 CN=EADMIN_STD,OU=Groups,DC=example,DC=com
 ```
 
+**Multiple Groups:**
+
+Use pipe separator (`|`) for users belonging to multiple groups:
+
+```text
+CN=EADMIN_STD,OU=Groups,DC=example,DC=com|CN=DEVELOPERS,OU=Groups,DC=example,DC=com
+```
+
 ### Sample CSV
 
+**Minimal Format** (only required columns):
+
 ```csv
-"User Name","Login ID","Email","Entitlement Attribute","Entitlement Display Name"
-"Alice Anderson","CN=USER001,OU=Users,DC=example,DC=com","alice@example.com","memberOf","CN=EADMIN_STD,OU=Groups,DC=example,DC=com"
-"Bob Brown","CN=USER002,OU=Users,DC=example,DC=com","bob@example.com","memberOf","CN=EADMIN_STD,OU=Groups,DC=example,DC=com"
+"Email","User Display Name","Employee Status","Entitlement Display Name"
+"alice@example.com","Alice Anderson","A","CN=EADMIN_STD,OU=Groups,DC=example,DC=com"
+"bob@example.com","Bob Brown","A","CN=DEVELOPERS,OU=Groups,DC=example,DC=com"
+"charlie@example.com","Charlie Chen","A","CN=EADMIN_STD,OU=Groups,DC=example,DC=com|CN=DEVELOPERS,OU=Groups,DC=example,DC=com"
 ```
+
+**Typical Export Format** (with additional metadata columns):
+
+```csv
+"User Name","Login ID","User Display Name","Cof Account Type","Application Name","Entitlement Attribute","Entitlement Display Name","Related Application","Sox","Job Level ","Job Title","Created Date","Account Locker","Employee Status","Email","Cost Center","Finc Level 4","Manager EID","Manager Name","Manager Email"
+"USER001","CN=USER001,OU=Developers,OU=All Users,DC=example,DC=com","Alice Anderson","User","Active Directory","memberOf","CN=EADMIN_STD,OU=Groups,DC=example,DC=com","Example App","true","50","Lead Software Engineer","2025-09-23 00:00:00","0","A","alice.anderson@example.com","IT Infrastructure","Network Engineering","MGR001","David Wilson","David.Wilson@example.com"
+```
+
+The tool automatically extracts only the required columns from your export.


### PR DESCRIPTION
## Summary

Fixes critical documentation bug where CSV format examples did not match the actual tool implementation, causing user validation errors.

## Problem

Users following the documentation received this error:
```
Error: CSV validation error: Missing required columns: {'Employee Status', 'User Display Name'}
```

The documented CSV format was incorrect:
- ❌ User Name (optional)
- ❌ Login ID (required)
- ❌ Entitlement Attribute (required)
- ✅ Email (required)
- ✅ Entitlement Display Name (required)

## Solution

Updated documentation to match actual implementation (`src/xc_user_group_sync/user_sync_service.py:152-157`):
- ✅ Email (required)
- ✅ User Display Name (required)
- ✅ Employee Status (required)
- ✅ Entitlement Display Name (required)

## Changes Made

1. **Corrected Required Columns Table**: Now accurately reflects the 4 columns the tool actually requires
2. **Added Employee Status Clarification**: Only `A` (case-insensitive) marks users as active
3. **Added Two CSV Format Examples**:
   - Minimal format (4 required columns only)
   - Typical export format (20 columns matching repository `User-Database.csv`)
4. **Clarified Extra Columns**: Tool ignores additional columns, making it compatible with full exports

## Testing

✅ Verified minimal CSV format works correctly  
✅ Verified repository `User-Database.csv` works correctly  
✅ All documented examples validated against actual tool behavior  
✅ All pre-commit hooks passed (PyMarkdown, EditorConfig, etc.)

## Impact

**Before**: Users could not successfully create CSV files following the documentation  
**After**: Users can create valid CSV files that work with the tool

Fixes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)