### PR TITLE
docs: fix broken internal documentation links

### DIFF
--- a/docs/CICD/github-actions.md
+++ b/docs/CICD/github-actions.md
@@ -124,7 +124,7 @@ Or add GitHub secrets: `PROXY_URL`, `CA_BUNDLE_PATH`  <!-- pragma: allowlist sec
 **Workflow fails with SSL error**:
 - Verify P12 certificate base64 encoding
 - Check `XC_P12_PASSWORD` matches certificate
-- See [Troubleshooting Guide](../troubleshooting.md#issue-4-corporate-proxy-and-mitm-ssl-interception)
+- See [Troubleshooting Guide](../troubleshooting.md#issue-4-corporate-proxy-configuration-and-authentication)
 
 **No changes applied**:
 - Check CSV format matches requirements

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,7 +132,7 @@ xc_user_group_sync --csv ./User-Database.csv \
 - Check `/etc/ssl/certs/` for CA bundle
 - Or contact your IT department
 
-For proxy troubleshooting, see [Troubleshooting Guide - Corporate Proxy](troubleshooting.md#issue-4-corporate-proxy-and-mitm-ssl-interception).
+For proxy troubleshooting, see [Troubleshooting Guide - Corporate Proxy](troubleshooting.md#issue-4-corporate-proxy-configuration-and-authentication).
 
 ## CSV Format
 

--- a/docs/specifications/user-group-sync-srs.md
+++ b/docs/specifications/user-group-sync-srs.md
@@ -70,7 +70,6 @@
    6.4 [Data Validation Rules](#64-data-validation-rules)
 
 7. [Development Requirements](#7-development-requirements)
-   See [`development/quality-standards.md`](development/quality-standards.md) for complete FR-DEV and SC-DEV requirements
 
 8. [Quality Attributes](#8-quality-attributes)
    8.1 [Testability](#81-testability)
@@ -83,14 +82,9 @@
    9.3 [Appendix C: Glossary](#93-appendix-c-glossary)
    9.4 [Appendix D: Change History](#94-appendix-d-change-history)
 
-**Implementation Guidance** (extracted to focused documents):
-- [`implementation/roadmap.md`](implementation/roadmap.md) - Feature priorities and phased implementation
-- [`implementation/workflows.md`](implementation/workflows.md) - Operational procedures (setup, sync, prune)
+**Implementation Guidance**:
+
 - [`implementation/testing-strategy.md`](implementation/testing-strategy.md) - Unit, integration, and E2E testing
-- [`guides/deployment-guide.md`](guides/deployment-guide.md) - Deployment scenarios overview
-- [`guides/github-actions-guide.md`](guides/github-actions-guide.md) - GitHub Actions configuration
-- [`guides/jenkins-guide.md`](guides/jenkins-guide.md) - Jenkins pipeline configuration
-- [`guides/troubleshooting-guide.md`](guides/troubleshooting-guide.md) - Diagnostic commands and resolutions
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1017,8 +1017,8 @@ If issue persists:
 
 ## Related Documentation
 
-- [Deployment Guide](CICD/deployment-guide.md) - Overview of deployment scenarios
-- [Operations Guide](operations-guide.md) - Step-by-step operational procedures
 - [Testing Strategy](specifications/implementation/testing-strategy.md) - Validation approaches
-- [GitHub Actions Guide](CICD/github-actions-guide.md) - CI/CD automation with GitHub
-- [Jenkins Guide](CICD/jenkins-guide.md) - CI/CD automation with Jenkins
+- [GitHub Actions](CICD/github-actions.md) - CI/CD automation with GitHub
+- [GitLab CI](CICD/gitlab-ci.md) - CI/CD automation with GitLab
+- [Jenkins](CICD/jenkins.md) - CI/CD automation with Jenkins
+- [Contributing Guide](contributing.md) - Development workflow and standards

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -296,4 +296,4 @@ For detailed troubleshooting guidance, see the [Troubleshooting Guide](troublesh
 
 - Authentication failures → See [Troubleshooting Guide - Authentication](troubleshooting.md#issue-1-authentication-failures)
 - CSV parsing errors → See [Troubleshooting Guide - CSV Parsing](troubleshooting.md#issue-2-csv-parsing-errors)
-- Corporate proxy issues → See [Troubleshooting Guide - Corporate Proxy](troubleshooting.md#issue-4-corporate-proxy-and-mitm-ssl-interception)
+- Corporate proxy issues → See [Troubleshooting Guide - Corporate Proxy](troubleshooting.md#issue-4-corporate-proxy-configuration-and-authentication)


### PR DESCRIPTION
Fixes #172

## Summary

Removes references to non-existent files and updates anchor links after Issue 4/5 restructuring in troubleshooting.md.

## Changes Made

### Files Modified

- **docs/troubleshooting.md**: Remove broken file references in Related Documentation section
- **docs/configuration.md**: Update anchor link to Issue 4 with new title
- **docs/usage.md**: Update anchor link to Issue 4
- **docs/CICD/github-actions.md**: Update anchor link to Issue 4
- **docs/specifications/user-group-sync-srs.md**: Remove broken file references

### Broken Links Removed

- `docs/CICD/deployment-guide.md` (does not exist)
- `docs/operations-guide.md` (does not exist)
- `docs/CICD/github-actions-guide.md` (does not exist)
- `docs/CICD/jenkins-guide.md` (does not exist)
- `docs/specifications/development/quality-standards.md` (does not exist)
- `docs/specifications/implementation/roadmap.md` (does not exist)
- `docs/specifications/implementation/workflows.md` (does not exist)

### Anchor Links Updated

- **Old**: `#issue-4-corporate-proxy-and-mitm-ssl-interception`
- **New**: `#issue-4-corporate-proxy-configuration-and-authentication`

### Existing Files Retained

All internal links now point to existing files:
- `specifications/implementation/testing-strategy.md`
- `CICD/github-actions.md`
- `CICD/gitlab-ci.md`
- `CICD/jenkins.md`
- `contributing.md`

## Verification

- ✅ All pre-commit hooks passed (PyMarkdown, editorconfig, detect-secrets)
- ✅ All internal links point to existing files
- ✅ All anchor links use correct heading IDs
- ✅ No broken references in Related Documentation sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)