### PR TITLE
docs: remove redundant Issue Resolution Workflow section

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -950,54 +950,6 @@ grep -i "failed" sync-debug.log
 
 ---
 
-## Issue Resolution Workflow
-
-### Step 1: Identify the Issue Category
-
-**Authentication Issues**:
-- Symptoms: HTTP 401, "Authentication failed"
-- Quick Check: Verify certificate validity and expiration
-
-**CSV Issues**:
-- Symptoms: "CSVParseError", "Missing required column"
-- Quick Check: Validate CSV structure and encoding
-
-**Network Issues**:
-- Symptoms: Connection timeout, "RequestException"
-- Quick Check: Test network connectivity and F5 XC status
-
-**Configuration Issues**:
-- Symptoms: "Configuration not found", missing environment variables
-- Quick Check: Verify .env file and environment variables
-
-### Step 2: Run Diagnostic Commands
-
-Use the appropriate diagnostic commands from the sections above to gather information about the issue.
-
-### Step 3: Apply Resolution Steps
-
-Follow the resolution steps for the identified issue category.
-
-### Step 4: Verify Resolution
-
-```bash
-# Test with dry-run
-xc_user_group_sync --csv User-Database.csv --dry-run
-
-# If dry-run succeeds, execute actual sync
-xc_user_group_sync --csv User-Database.csv
-```
-
-### Step 5: Document and Escalate (if needed)
-
-If issue persists:
-1. Capture full debug output
-2. Document steps taken
-3. Check for known issues in repository
-4. Contact F5 support or open GitHub issue
-
----
-
 ## Common Error Messages Reference
 
 | Error Message | Likely Cause | Resolution |


### PR DESCRIPTION
Fixes #176

## Summary

Removes the redundant "Issue Resolution Workflow" section from troubleshooting.md to reduce duplication and streamline documentation.

## Changes Made

**Section Removed**: "Issue Resolution Workflow" (lines 953-998)
- Step 1: Identify the Issue Category
- Step 2: Run Diagnostic Commands
- Step 3: Apply Resolution Steps
- Step 4: Verify Resolution
- Step 5: Document and Escalate (if needed)

**Total Reduction**: 48 lines of redundant content

## Rationale

The removed workflow section provided generic troubleshooting steps already covered throughout the documentation:

1. **Common Issues and Resolutions**: Each issue section (1-5) already contains:
   - Symptoms identification
   - Diagnostic tests
   - Complete resolution steps
   - Verification commands

2. **Diagnostic Commands**: Comprehensive diagnostic guidance including:
   - Configuration checks
   - Python interactive debugging
   - API connectivity tests
   - CSV validation
   - Log analysis

3. **Quick Diagnostic Guide**: Issue 4 already provides a decision tree routing users to appropriate subsections

## What Remains

All essential troubleshooting content is preserved:
- ✅ Common Issues and Resolutions (Issues 1-5)
- ✅ Diagnostic Commands (comprehensive)
- ✅ Common Error Messages Reference (quick lookup table)
- ✅ Related Documentation (links to other resources)

## Benefits

- **Reduced Redundancy**: Eliminated duplicate guidance already in issue sections
- **Faster Navigation**: Users find specific solutions without generic workflow steps
- **Clearer Focus**: Each issue section is self-contained with complete resolution steps
- **Maintained Coverage**: No loss of troubleshooting information or guidance

## Verification

- ✅ All pre-commit hooks passed (PyMarkdown, editorconfig, detect-secrets)
- ✅ Documentation structure remains logical and complete
- ✅ All cross-references and links intact
- ✅ No loss of essential troubleshooting information

🤖 Generated with [Claude Code](https://claude.com/claude-code)