### PR TITLE
chore: add .serena/ to gitignore for security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ Thumbs.db
 *.swo
 *~
 
+# AI assistant local data (may contain sensitive project-specific info)
+.serena/
+
 # Logs
 *.log
 


### PR DESCRIPTION
## Summary
- Add AI assistant local data directory to gitignore to prevent accidental commits of sensitive project-specific information

## Changes
- Added `.serena/` to `.gitignore` with explanatory comment

## Rationale
The `.serena/` directory contains:
- AI assistant memory files that may contain customer-specific information
- Cache files with local project context
- Environment-specific paths and configurations

This follows the official Serena recommendation to ignore this folder for security reasons.

## Test plan
- [x] Verify `.serena/` directory is now ignored by git
- [x] Existing files in `.serena/` remain on disk but won't be tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)